### PR TITLE
Update QB.md

### DIFF
--- a/QB.md
+++ b/QB.md
@@ -78,6 +78,8 @@
     1.  Subject ID
     
     2.  Level ID
+    
+    3. Partner IDs
 
 2.  Receive JSON of "available questions data"
 


### PR DESCRIPTION
We need to pass partner ids as well when sending request to get question availability statistics as we might want to create new exam only for one partner, right.